### PR TITLE
Python wrapper for types and dumpings

### DIFF
--- a/genevo/c/error.c
+++ b/genevo/c/error.c
@@ -13,6 +13,8 @@ const char * get_err_string(const uint8_t errcode) {
 		case ERR_CANNOT_MALLOC:
 			return ERR_CANNOT_MALLOC_STR;
 			break;
+		case ERR_OUT_OF_BOUNDS:
+			return ERR_OUT_OF_BOUNDS_STR;
 		case ERR_FILE_CANNOT_OPEN:
 			return ERR_FILE_CANNOT_OPEN_STR;
 			break;

--- a/genevo/c/error.h
+++ b/genevo/c/error.h
@@ -10,13 +10,20 @@ extern uint8_t ERROR_LEVEL;
 
 
 #define ERR_OK                              0x00
-#define ERR_OK_STR                         "No errors."
+#define ERR_OK_STR                          "No errors."
 
 
 // System errors ===============================================================
 
-#define ERR_CANNOT_MALLOC                  0xf0
-#define ERR_CANNOT_MALLOC_STR              "Cannot allocate memory."
+#define ERR_CANNOT_MALLOC                   0xf0
+#define ERR_CANNOT_MALLOC_STR               "Cannot allocate memory."
+
+
+// General errors ==============================================================
+
+#define ERR_OUT_OF_BOUNDS                   0xe0
+#define ERR_OUT_OF_BOUNDS_STR               "You are trying to read out of "   \
+                                            "array bounds."
 
 
 // Gene pool file errors =======================================================

--- a/genevo/c/gene_pool.h
+++ b/genevo/c/gene_pool.h
@@ -2,22 +2,15 @@
 
 #include <stdint.h>
 
+#include "pickler.h"
 #include "files.h"
 
-
-// Even the empty pool file should be at least 64 bits long.
-#define POOL_FILE_MIN_SAFE_BIT_SIZE 64
-
-#define POOL_INITIAL_BYTE           (uint8_t) 0xAB
-#define POOL_META_INITIAL_BYTE      (uint8_t) 0xBC
-#define POOL_META_TERMINAL_BYTE     (uint8_t) 0xCD
-#define POOL_TERMINAL_BYTE          (uint8_t) 0xFF
-
-#define GENOME_INITIAL_BYTE         (uint8_t) 0xA0
-#define GENOME_META_INITIAL_BYTE    (uint8_t) 0xDE
-#define GENOME_META_TERMINAL_BYTE   (uint8_t) 0xEF
-#define GENOME_RESIDUE_BYTE         (uint8_t) 0xA2
-#define GENOME_TERMINAL_BYTE        (uint8_t) 0xA1
+#define GENE_OUTCOME_IS_INPUT        0b10000000
+#define GENE_OUTCOME_IS_INTERMEDIATE 0b01000000
+#define GENE_OUTCOME_IS_OUTPUT       0b00100000
+#define GENE_INCOME_IS_INPUT         0b00010000
+#define GENE_INCOME_IS_INTERMEDIATE  0b00001000
+#define GENE_INCOME_IS_OUTPUT        0b00000100
 
 /*
 
@@ -54,14 +47,9 @@ This number can be increased with maximizing the number of bits.
 
 */
 
-#define GENE_OUTCOME_IS_INPUT        0b10000000
-#define GENE_OUTCOME_IS_INTERMEDIATE 0b01000000
-#define GENE_OUTCOME_IS_OUTPUT       0b00100000
-#define GENE_INCOME_IS_INPUT         0b00010000
-#define GENE_INCOME_IS_INTERMEDIATE  0b00001000
-#define GENE_INCOME_IS_OUTPUT        0b00000100
-
 typedef uint8_t gene_byte_t;
+#define GENE_BYTE_SIZE sizeof(gene_byte_t)
+
 typedef struct gene_s {
     uint64_t outcome_node_id;
     uint64_t income_node_id;
@@ -77,44 +65,6 @@ typedef struct gene_s {
     double   weight;           // weight is normalized to [-1; 1]
 } gene_t;
 
-/*
-
-Structure of the genome in the memory is the following:
-
-Content                               Size         Note
-----------                            ----------   ----------
-GENOME_INITIAL_BYTE                   8            Start byte of the genome
-[number of genes]                     32
-MNSB                                  16           Size of the metadata which
-                                                   describes this genome.
-GENOME_META_INITIAL_BYTE              8            Start byte of the metadata.
-MN                                    MNSb         The metadata itself
-GENOME_META_TERMINAL_BYTE             8            End byte of the metadata.
-[gene #1]                             2*IGSb + WGSb
-[gene #2]                             2*IGSb + WGSb
-...
-GENOME_RESIDUE_BYTE                   8            Genome residue byte
-[size of the residue in bits=RSb]     16           Size of the residual genome*.
-...                                   RSb          Residual genome.
-GENOME_TERMINAL_BYTE                  8            End byte of the genome
-
-* Maximum size of a gene in bits is 255*2 + 255 = 765. Just 10 bits is enough
-  To encode this number, but that would be unconvenient to put into struct, so
-  16 chosen instead.
-
-If the size of the genome cannot be aligned to size of the single gene (i.e.
-genome contains some terminal bits that are not anough to form the new gene),
-the residue can be placed after GENOME_RESIDUE_BYTE.
-
-*/
-
-typedef struct genome_preamble_s {
-    uint8_t   initial_byte;
-    uint32_t  genes_number;
-    uint16_t  metadata_byte_size;
-    uint8_t   metadata_initial_byte;
-} __attribute__((packed, aligned(1))) genome_file_preamble_t;
-
 typedef struct genome_s {
     uint32_t      length;
     uint8_t      *metadata;
@@ -123,49 +73,6 @@ typedef struct genome_s {
     uint16_t      residue_size_bits;
     uint8_t      *residue;
 } genome_t;
-
-/*
-
-Structure of the gene pool written in the file is the following:
-
-Content                               Size (bits)  Note
-----------                            ----------   ----------
-POOL_INITIAL_BYTE                     8            Initial byte used to verify
-                                                   integrity of the file
-[number of organisms]                 64
-[number of input neurons]             64
-[number of output neurons]            64
-[size of the OG and IG in bits]       8
-[size of the WG in bits]              8
-[size of metadata in bytes = MPSB]    16           Metadata contains desription
-                                                   of this gene pool
-POOL_META_INITIAL_BYTE                8            Start byte of the metadata
-MP                                    MPSb         The metadata itself
-POOL_META_TERMINAL_BYTE               8            End byte of the metadata
-[genome of the organism #1]           -
-[genome of the organism #2]           -
-...
-POOL_TERMINAL_BYTE                    8            End byte used to verify
-                                                   integrity of the file.
-
-! Note, that OG and IG has the same size.
-
-! Note, that size of OG in bits (OGSb) can be encoded with 8-bit number. That
-  means, maximum OGSb value can be 255. Maximum value for number, which consists
-  of 255 bits is 5.789604e+76, which is pretty large.
-
-*/
-
-typedef struct pool_file_preamble_s {
-    uint8_t  initial_byte;
-    uint64_t organisms_number;
-    uint64_t input_neurons_number;
-    uint64_t output_neurons_number;
-    uint8_t  node_id_part_bit_size;
-    uint8_t  weight_part_bit_size;
-    uint16_t metadata_byte_size;
-    uint8_t  metadata_initial_byte;
-} __attribute__((packed, aligned(1))) pool_file_preamble_t;
 
 typedef struct pool_s {
     uint64_t    organisms_number;

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -328,10 +328,16 @@ void copy_uint64_to_bitslots(
 #define MAX_FOR_BIT(_BIT_SIZE) \
     ((_BIT_SIZE) == 64 ? 0xffffffffffff : (1 << (_BIT_SIZE)) - 1)
 
-uint8_t * point_gene_by_index(
+uint8_t * point_gene_in_genome_by_index(
     genome_t *genome, uint32_t index, pool_t *pool
 ) {
     return genome->genes + (pool->gene_bytes_size * index);
+}
+
+uint8_t * point_gene_by_index(
+    uint8_t *genes, uint32_t index, pool_t *pool
+) {
+    return genes + (pool->gene_bytes_size * index);
 }
 
 /*
@@ -422,7 +428,9 @@ gene_t * get_gene_by_pointer(
 
 }
 
-gene_t * get_gene_by_index(genome_t *genome, uint32_t index, pool_t *pool) {
+gene_t * get_gene_in_genome_by_index(
+    genome_t *genome, uint32_t index, pool_t *pool
+) {
 
     #ifndef SKIP_CHECK_BOUNDS
     if (index >= genome->length) {
@@ -432,7 +440,16 @@ gene_t * get_gene_by_index(genome_t *genome, uint32_t index, pool_t *pool) {
     #endif
 
     return get_gene_by_pointer(
-        point_gene_by_index(genome, index, pool),
+        point_gene_in_genome_by_index(genome, index, pool),
+        pool 
+    );
+
+}
+
+gene_t * get_gene_by_index(uint8_t *genes, uint32_t index, pool_t *pool) {
+
+    return get_gene_by_pointer(
+        point_gene_by_index(genes, index, pool),
         pool
     );
 

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -470,16 +470,17 @@ gene_byte_t * generate_genes_byte_array(
             start_byte,
             0,
             pool->node_id_part_bit_size);
+
         copy_uint64_to_bitslots(
             &income_node_id,
             start_byte,
-            pool->node_id_part_bit_size + 1,
+            pool->node_id_part_bit_size,
             pool->node_id_part_bit_size);
 
         copy_uint64_to_bitslots(
             (uint64_t *)&(gene->weight_unnormalized),
             start_byte,
-            pool->node_id_part_bit_size * 2 + 1,
+            pool->node_id_part_bit_size * 2,
             pool->weight_part_bit_size);
 
     }

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -355,7 +355,6 @@ and output ranges. New ID to `_ID` and type to `_CONNECTION_TYPE_VAR`.
                            _NODES_CAPACITY,                                    \
                            _CONNECTION_TYPE_VAR, _DIRECTION)                   \
 {                                                                              \
-    _CONNECTION_TYPE_VAR = 0;                                                  \
     if (_ID < _INPUT_RANGE_SIZE)                                               \
         _CONNECTION_TYPE_VAR |= GENE_  ## _DIRECTION ## _IS_INPUT;             \
     else                                                                       \
@@ -378,11 +377,9 @@ and output ranges. New ID to `_ID` and type to `_CONNECTION_TYPE_VAR`.
 }
 
 
-gene_t * get_gene_by_pointer(
-    uint8_t *gene_start_byte, pool_t *pool
-) {
+gene_t * get_gene_by_pointer(uint8_t *gene_start_byte, pool_t *pool) {
 
-    gene_t *gene = calloc(1, sizeof(gene_t));
+    gene_t *gene = malloc(sizeof(gene_t));
 
     copy_bitslots_to_uint64(
         gene_start_byte,
@@ -407,6 +404,8 @@ gene_t * get_gene_by_pointer(
         gene->weight_unnormalized / MAX_FOR_BIT(pool->weight_part_bit_size);
 
     uint64_t nodes_capacity = MAX_FOR_BIT(pool->node_id_part_bit_size);
+
+    gene->connection_type = 0;
 
     // outcome node
     ASSIGN_TYPE_BY_ID(

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -437,9 +437,9 @@ gene_byte_t * generate_genes_byte_array(
     gene_t **genes, pool_t *pool, uint64_t length
 ) {
 
-    gene_byte_t *array = malloc(
-        sizeof(gene_byte_t) * length * pool->gene_bytes_size);
-
+    gene_byte_t *array = calloc(
+        sizeof(gene_byte_t),
+        length * pool->gene_bytes_size);
 
     uint64_t nodes_capacity = MAX_FOR_BIT(pool->gene_bytes_size);
 

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -464,6 +464,8 @@ gene_t * get_gene_by_pointer(
 
 gene_t * get_gene_by_index(genome_t *genome, uint32_t index, pool_t *pool) {
 
+    // TODO: set ERROR_LEVEL when index is out of bounds
+
     return get_gene_by_pointer(
         point_gene_by_index(genome, index, pool),
         pool

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -377,7 +377,7 @@ uint8_t * point_gene_by_index(
     return genome->genes + (pool->gene_bytes_size * index);
 }
 
-inline gene_t * get_gene_by_pointer(
+gene_t * get_gene_by_pointer(
     uint8_t *gene_start_byte, pool_t *pool
 ) {
 

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -478,18 +478,15 @@ gene_byte_t * generate_genes_byte_array(
     gene_byte_t *array = malloc(
         sizeof(gene_byte_t) * length * pool->gene_bytes_size);
 
-    uint64_t counter = 0;
-    gene_byte_t* start_byte;
-    gene_t* gene;
 
     uint64_t nodes_capacity = MAX_FOR_BIT(pool->gene_bytes_size);
 
-    for (
-        uint64_t counter = 0; counter < length;
-        counter++,
-        start_byte = array + counter * pool->gene_bytes_size,
-        gene = genes[counter]
-    ) {
+    gene_byte_t* start_byte;
+    gene_t* gene;
+    for (uint64_t counter = 0; counter < length; counter++) {
+
+        start_byte = array + counter * pool->gene_bytes_size;
+        gene = genes[counter];
 
         uint64_t outcome_node_id = gene->outcome_node_id,
                  income_node_id = gene->income_node_id;

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -395,7 +395,7 @@ and output ranges. New ID to `_ID` and type to `_CONNECTION_TYPE_VAR`.
     else                                                                       \
     if (_ID > _NODES_CAPACITY - _OUTPUT_RANGE_SIZE) {                          \
         _CONNECTION_TYPE_VAR |= GENE_ ## _DIRECTION ## _IS_OUTPUT;             \
-        _ID -= _NODES_CAPACITY + _OUTPUT_RANGE_SIZE + 1; }                     \
+        _ID -= _NODES_CAPACITY - _OUTPUT_RANGE_SIZE + 1; }                     \
     else {                                                                     \
         _CONNECTION_TYPE_VAR |= GENE_ ## _DIRECTION ## _IS_INTERMEDIATE;       \
         _ID -= _INPUT_RANGE_SIZE; }                                            \
@@ -440,7 +440,7 @@ gene_t * get_gene_by_pointer(
     gene->weight =
         gene->weight_unnormalized / MAX_FOR_BIT(pool->weight_part_bit_size);
 
-    uint64_t nodes_capacity = MAX_FOR_BIT(pool->gene_bytes_size);
+    uint64_t nodes_capacity = MAX_FOR_BIT(pool->node_id_part_bit_size);
 
     // outcome node
     ASSIGN_TYPE_BY_ID(

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -10,7 +10,7 @@ This module contains methods for dumping gene pool into file and vice versa.
 #define sizeof_member(type, member) sizeof(((type *)0)->member)
 
 #define MAPPING_FAIL_CONDITION(_CONDITION, _ERR_CONST) \
-    if(_CONDITION) {ERROR_LEVEL = _ERR_CONST; close_file(mapping); return NULL;}
+    if(_CONDITION) {ERROR_LEVEL = (_ERR_CONST); close_file(mapping); return NULL;}
 
 pool_t * read_pool(const char *address) {
 
@@ -369,7 +369,7 @@ void copy_uint64_to_bitslots(
 }
 
 #define MAX_FOR_BIT(_BIT_SIZE) \
-    (_BIT_SIZE == 64 ? 0xffffffffffff : (1 << _BIT_SIZE) - 1)
+    ((_BIT_SIZE) == 64 ? 0xffffffffffff : (1 << (_BIT_SIZE)) - 1)
 
 uint8_t * point_gene_by_index(
     genome_t *genome, uint32_t index, pool_t *pool
@@ -382,6 +382,9 @@ uint8_t * point_gene_by_index(
 Guess node type (input, output or intermediate) by its ID and sizes of input
 and output ranges. New ID to `_ID` and type to `_CONNECTION_TYPE_VAR`.
 `_DIRECTION` should be one of "INPUT" or "OUTPUT".
+
+! Potential bug: _ID will be calculated several times when passed as the
+  expression.
 
 */
 #define ASSIGN_TYPE_BY_ID(_ID,                                                 \

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -442,9 +442,15 @@ gene_byte_t * generate_genes_byte_array(
     gene_t **genes, pool_t *pool, uint64_t length
 ) {
 
-    gene_byte_t *array = calloc(
-        sizeof(gene_byte_t),
-        length * pool->gene_bytes_size);
+    #define GENES_ARRAY_SIZE \
+        (sizeof(gene_byte_t) * length * pool->gene_bytes_size)
+
+    // 8 auxiliary bytes is malloc'ed here, because
+    // copy_uint64_to_bitslots can cause writing out of bounds.
+    gene_byte_t *array = malloc(GENES_ARRAY_SIZE + 8);
+    memset(array, 0, GENES_ARRAY_SIZE);
+
+    #undef GENES_ARRAY_SIZE
 
     uint64_t nodes_capacity = MAX_FOR_BIT(pool->gene_bytes_size);
 

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -499,3 +499,9 @@ gene_byte_t * generate_genes_byte_array(
     return array;
 
 }
+
+void free_genes_byte_array(gene_byte_t *array) {
+
+    free(array);
+
+}

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -292,49 +292,6 @@ copied bits into number, so now:
 number == 0b00000000...0000000010101111, sizeof(number) == 64
 
 */
-// void copy_bitslots_to_uint64__endianless(
-//     uint8_t *slots, uint64_t *number, uint8_t start, uint8_t end
-// ) {
-
-//     *number = 0;
-
-//     // right offset of the first bit in `number`
-//     uint8_t number_offset = end - start + 1;
-
-//     for(
-//         uint8_t slot_n = start / 8;
-//         slot_n <= end / 8;
-//         slot_n++
-//     ) {
-
-//         uint8_t slot = slots[slot_n];
-//         uint16_t offset;
-
-//         // there's some left offset in the current slot present
-//         if (slot_n * 8 < start) {
-//             offset = start - slot_n * 8;
-//             *number |=
-//                 LEFT_ZERO_UINT8(slot, offset) << (number_offset - 8 + offset);
-//         }
-
-//         // there's right offset
-//         else if ((end + 1) < (slot_n + 1) * 8) {
-//             offset = (slot_n + 1) * 8 - end - 1;
-//             *number |= RIGHT_ZERO_UINT8(slot, offset) >> offset;
-//         }
-
-//         // copy the whole byte
-//         else {
-//             offset = 0;
-//             *number |= slot << (number_offset - 8);
-//         }
-
-//         number_offset -= 8 - offset;
-
-//     }
-
-// }
-
 void copy_bitslots_to_uint64(
     uint8_t *slots, uint64_t *number, uint8_t start, uint8_t end
 ) {

--- a/genevo/c/pickler.c
+++ b/genevo/c/pickler.c
@@ -424,7 +424,12 @@ gene_t * get_gene_by_pointer(
 
 gene_t * get_gene_by_index(genome_t *genome, uint32_t index, pool_t *pool) {
 
-    // TODO: set ERROR_LEVEL when index is out of bounds
+    #ifndef SKIP_CHECK_BOUNDS
+    if (index >= genome->length) {
+        ERROR_LEVEL = ERR_OUT_OF_BOUNDS;
+        return NULL;
+    }
+    #endif
 
     return get_gene_by_pointer(
         point_gene_by_index(genome, index, pool),

--- a/genevo/c/pickler.h
+++ b/genevo/c/pickler.h
@@ -137,8 +137,10 @@ void copy_uint64_to_bitslots(
     uint8_t start, uint8_t number_size
 );
 
-uint8_t * point_gene_by_index(genome_t *, uint32_t, pool_t *);
-gene_t * get_gene_by_index(genome_t *, uint32_t, pool_t *);
+uint8_t * point_gene_in_genome_by_index(genome_t *, uint32_t index, pool_t *);
+uint8_t * point_gene_by_index(uint8_t *genes, uint32_t index, pool_t *pool);
+gene_t * get_gene_in_genome_by_index(genome_t *, uint32_t, pool_t *);
+gene_t * get_gene_by_index(uint8_t *genes, uint32_t index, pool_t *);
 gene_t * get_gene_by_pointer(uint8_t *gene_start_byte, pool_t *);
 
 pool_t * read_pool(const char *address);

--- a/genevo/c/pickler.h
+++ b/genevo/c/pickler.h
@@ -144,6 +144,7 @@ gene_t * get_gene_by_pointer(uint8_t *gene_start_byte, pool_t *);
 pool_t * read_pool(const char *address);
 void close_pool(pool_t *pool);
 void write_pool(const char *address, pool_t *pool, genome_t **genomes);
+gene_byte_t * generate_genes_byte_array(gene_t **, pool_t *, uint64_t length);
 
 genome_t * read_next_genome(pool_t *pool);
 void reset_genome_cursor(pool_t *pool);

--- a/genevo/c/pickler.h
+++ b/genevo/c/pickler.h
@@ -145,6 +145,7 @@ pool_t * read_pool(const char *address);
 void close_pool(pool_t *pool);
 void write_pool(const char *address, pool_t *pool, genome_t **genomes);
 gene_byte_t * generate_genes_byte_array(gene_t **, pool_t *, uint64_t length);
+void free_genes_byte_array(gene_byte_t *array);
 
 genome_t * read_next_genome(pool_t *pool);
 void reset_genome_cursor(pool_t *pool);

--- a/genevo/c/pickler.h
+++ b/genevo/c/pickler.h
@@ -16,9 +16,110 @@
 #include "error.h"
 #include "files.h"
 
-#define BYTE_SIZE sizeof(uint8_t)
+// Even the empty pool file should be at least 64 bits long.
+#define POOL_FILE_MIN_SAFE_BIT_SIZE 64
 
-#define IS_BIG_ENDIAN (!*(uint8_t *)&(uint16_t){1})
+#define POOL_INITIAL_BYTE           (uint8_t) 0xAB
+#define POOL_META_INITIAL_BYTE      (uint8_t) 0xBC
+#define POOL_META_TERMINAL_BYTE     (uint8_t) 0xCD
+#define POOL_TERMINAL_BYTE          (uint8_t) 0xFF
+
+#define GENOME_INITIAL_BYTE         (uint8_t) 0xA0
+#define GENOME_META_INITIAL_BYTE    (uint8_t) 0xDE
+#define GENOME_META_TERMINAL_BYTE   (uint8_t) 0xEF
+#define GENOME_RESIDUE_BYTE         (uint8_t) 0xA2
+#define GENOME_TERMINAL_BYTE        (uint8_t) 0xA1
+
+/*
+
+! The notation defined in gene_pool.h is used here. (So MNSb means the size of
+  metadata of a genome in bits, for example.)
+
+Structure of the genome in the memory is the following:
+
+Content                               Size         Note
+----------                            ----------   ----------
+GENOME_INITIAL_BYTE                   8            Start byte of the genome
+[number of genes]                     32
+MNSB                                  16           Size of the metadata which
+                                                   describes this genome.
+GENOME_META_INITIAL_BYTE              8            Start byte of the metadata.
+MN                                    MNSb         The metadata itself
+GENOME_META_TERMINAL_BYTE             8            End byte of the metadata.
+[gene #1]                             2*IGSb + WGSb
+[gene #2]                             2*IGSb + WGSb
+...
+GENOME_RESIDUE_BYTE                   8            Genome residue byte
+[size of the residue in bits=RSb]     16           Size of the residual genome*.
+...                                   RSb          Residual genome.
+GENOME_TERMINAL_BYTE                  8            End byte of the genome
+
+* Maximum size of a gene in bits is 255*2 + 255 = 765. Just 10 bits is enough
+  To encode this number, but that would be unconvenient to put into struct, so
+  16 chosen instead.
+
+If the size of the genome cannot be aligned to size of the single gene (i.e.
+genome contains some terminal bits that are not anough to form the new gene),
+the residue can be placed after GENOME_RESIDUE_BYTE.
+
+*/
+
+typedef struct genome_preamble_s {
+    uint8_t   initial_byte;
+    uint32_t  genes_number;
+    uint16_t  metadata_byte_size;
+    uint8_t   metadata_initial_byte;
+} __attribute__((packed, aligned(1))) genome_file_preamble_t;
+
+/*
+
+Structure of the gene pool written in the file is the following:
+
+Content                               Size (bits)  Note
+----------                            ----------   ----------
+POOL_INITIAL_BYTE                     8            Initial byte used to verify
+                                                   integrity of the file
+[number of organisms]                 64
+[number of input neurons]             64
+[number of output neurons]            64
+[size of the OG and IG in bits]       8
+[size of the WG in bits]              8
+[size of metadata in bytes = MPSB]    16           Metadata contains desription
+                                                   of this gene pool
+POOL_META_INITIAL_BYTE                8            Start byte of the metadata
+MP                                    MPSb         The metadata itself
+POOL_META_TERMINAL_BYTE               8            End byte of the metadata
+[genome of the organism #1]           -
+[genome of the organism #2]           -
+...
+POOL_TERMINAL_BYTE                    8            End byte used to verify
+                                                   integrity of the file.
+
+! Note, that OG and IG has the same size.
+
+! Note, that size of OG in bits (OGSb) can be encoded with 8-bit number. That
+  means, maximum OGSb value can be 255. Maximum value for number, which consists
+  of 255 bits is 5.789604e+76, which is pretty large.
+
+*/
+
+typedef struct pool_file_preamble_s {
+    uint8_t  initial_byte;
+    uint64_t organisms_number;
+    uint64_t input_neurons_number;
+    uint64_t output_neurons_number;
+    uint8_t  node_id_part_bit_size;
+    uint8_t  weight_part_bit_size;
+    uint16_t metadata_byte_size;
+    uint8_t  metadata_initial_byte;
+} __attribute__((packed, aligned(1))) pool_file_preamble_t;
+
+/*
+
+All data structures is being dumped into the file using using network byte
+order which is big-endian.
+
+*/
 
 #define hton16 htons
 #define ntoh16 ntohs

--- a/genevo/c/pickler.h
+++ b/genevo/c/pickler.h
@@ -37,8 +37,8 @@ void copy_uint64_to_bitslots(
 );
 
 uint8_t * point_gene_by_index(genome_t *, uint32_t, pool_t *);
-
 gene_t * get_gene_by_index(genome_t *, uint32_t, pool_t *);
+gene_t * get_gene_by_pointer(uint8_t *gene_start_byte, pool_t *);
 
 pool_t * read_pool(const char *address);
 void close_pool(pool_t *pool);

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -84,15 +84,16 @@ write_pool = ctypes.CFUNCTYPE(
     genome_struct_p_p
 )(('write_pool', libc))
 
-point_gene_by_index = ctypes.CFUNCTYPE(
-    c_uint8_p,
+get_gene_in_genome_by_index = ctypes.CFUNCTYPE(
+    gene_struct_p,
     genome_struct_p,
+    c_uint32,
     pool_struct_p
-)(('point_gene_by_index', libc))
+)(('get_gene_in_genome_by_index', libc))
 
 get_gene_by_index = ctypes.CFUNCTYPE(
     gene_struct_p,
-    genome_struct_p,
+    gene_p,
     c_uint32,
     pool_struct_p
 )(('get_gene_by_index', libc))

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -33,6 +33,7 @@ class genome_struct_t(ctypes.Structure):
 
 
 genome_struct_p = ctypes.POINTER(genome_struct_t)
+genome_struct_p_p = ctypes.POINTER(genome_struct_p)
 
 
 class file_mapping_struct_t(ctypes.Structure):
@@ -75,57 +76,57 @@ write_pool = libc.write_pool
 write_pool.restype = None
 write_pool.argtypes = [
     c_char_p,  # address
-    ctypes.POINTER(pool_struct_t),  # pool
-    ctypes.POINTER(ctypes.POINTER(genome_struct_t))
+    pool_struct_p,  # pool
+    genome_struct_p_p
 ]
 
 point_gene_by_index = libc.point_gene_by_index
 point_gene_by_index.restype = c_uint8_p
 point_gene_by_index.argtypes = [
-    ctypes.POINTER(genome_struct_t),
-    ctypes.POINTER(pool_struct_t)
+    genome_struct_p,
+    pool_struct_p
 ]
 
 get_gene_by_index = libc.get_gene_by_index
-get_gene_by_index.restype = ctypes.POINTER(gene_struct_t)
+get_gene_by_index.restype = gene_struct_p
 get_gene_by_index.argtypes = [
-    ctypes.POINTER(genome_struct_t),
-    ctypes.POINTER(pool_struct_t)
+    genome_struct_p,
+    pool_struct_p
 ]
 
 get_gene_by_pointer = libc.get_gene_by_pointer
-get_gene_by_pointer.restype = ctypes.POINTER(gene_struct_t)
+get_gene_by_pointer.restype = gene_struct_p
 get_gene_by_pointer.argtypes = [
     gene_p,  # pointer
-    ctypes.POINTER(pool_struct_t)
+    pool_struct_p
 ]
 
 read_pool = libc.read_pool
-read_pool.restype = ctypes.POINTER(pool_struct_t)
+read_pool.restype = pool_struct_p
 read_pool.argtypes = [
     c_char_p  # address
 ]
 
-close_pool = ctypes.CFUNCTYPE(None, ctypes.POINTER(pool_struct_t))
+# close_pool = ctypes.CFUNCTYPE(None, pool_struct_p)
 
 read_next_genome = libc.read_next_genome
-read_next_genome.restype = ctypes.POINTER(genome_struct_t)
+read_next_genome.restype = genome_struct_p
 read_next_genome.argtypes = [
-    ctypes.POINTER(pool_struct_t)
+    pool_struct_p
 ]
 
 read_genomes = libc.read_genomes
-read_genomes.restype = ctypes.POINTER(ctypes.POINTER(genome_struct_t))
+read_genomes.restype = genome_struct_p_p
 read_genomes.argtypes = [
-    ctypes.POINTER(pool_struct_t)
+    pool_struct_p
 ]
 
 reset_genome_cursor = libc.reset_genome_cursor
 reset_genome_cursor.restype = None
-reset_genome_cursor.argtypes = [ctypes.POINTER(pool_struct_t)]
+reset_genome_cursor.argtypes = [pool_struct_p]
 
 free_genomes_ptrs = libc.free_genomes_ptrs
 free_genomes_ptrs.restype = None
 free_genomes_ptrs.argtypes = [
-    ctypes.POINTER(ctypes.POINTER(genome_struct_t))
+    genome_struct_p_p
 ]

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -110,6 +110,11 @@ generate_genes_byte_array = ctypes.CFUNCTYPE(
     c_uint64  # number of genes
 )(('generate_genes_byte_array', libc))
 
+free_genes_byte_array = ctypes.CFUNCTYPE(
+    None,
+    gene_p
+)(('free_genes_byte_array', libc))
+
 read_pool = ctypes.CFUNCTYPE(
     pool_struct_p,
     c_char_p  # address

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -5,6 +5,8 @@ c_uint8_p = ctypes.POINTER(c_uint8)  # equal to c_char_p
 
 libc = ctypes.cdll.LoadLibrary("genevo/c/bin/genevo.so")
 
+gene_p = c_uint8_p
+
 
 class gene_struct_t(ctypes.Structure):
     _fields_ = [
@@ -76,6 +78,13 @@ get_gene_by_index = libc.get_gene_by_index
 get_gene_by_index.restype = ctypes.POINTER(gene_struct_t)
 get_gene_by_index.argtypes = [
     ctypes.POINTER(genome_struct_t),
+    ctypes.POINTER(pool_struct_t)
+]
+
+get_gene_by_pointer = libc.get_gene_by_pointer
+get_gene_by_pointer.restype = ctypes.POINTER(gene_struct_t)
+get_gene_by_pointer.argtypes = [
+    gene_p,  # pointer
     ctypes.POINTER(pool_struct_t)
 ]
 

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -19,6 +19,7 @@ class gene_struct_t(ctypes.Structure):
 
 
 gene_struct_p = ctypes.POINTER(gene_struct_t)
+gene_struct_p_p = ctypes.POINTER(gene_struct_p)
 
 
 class genome_struct_t(ctypes.Structure):
@@ -87,6 +88,7 @@ point_gene_by_index = ctypes.CFUNCTYPE(
 get_gene_by_index = ctypes.CFUNCTYPE(
     gene_struct_p,
     genome_struct_p,
+    c_uint32,
     pool_struct_p
 )(('get_gene_by_index', libc))
 
@@ -95,6 +97,11 @@ get_gene_by_pointer = ctypes.CFUNCTYPE(
     gene_p,  # pointer
     pool_struct_p
 )(('get_gene_by_pointer', libc))
+
+generate_genes_byte_array = ctypes.CFUNCTYPE(
+    gene_p,
+    gene_struct_p_p
+)(('generate_genes_byte_array', libc))
 
 read_pool = ctypes.CFUNCTYPE(
     pool_struct_p,

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -1,6 +1,11 @@
 import ctypes
 
-from ctypes import c_uint8, c_uint16, c_uint32, c_uint64, c_void_p, c_char_p
+c_uint8 = ctypes.c_uint8
+c_uint16 = ctypes.c_uint16
+c_uint32 = ctypes.c_uint32
+c_uint64 = ctypes.c_uint64
+c_void_p = ctypes.c_void_p
+c_char_p = ctypes.c_char_p
 c_uint8_p = ctypes.POINTER(c_uint8)  # equal to c_char_p
 
 libc = ctypes.cdll.LoadLibrary("genevo/c/bin/genevo.so")

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -66,67 +66,56 @@ class pool_struct_t(ctypes.Structure):
 pool_struct_p = ctypes.POINTER(pool_struct_t)
 
 
-get_err_string = libc.get_err_string
-get_err_string.restype = c_char_p
-get_err_string.argtypes = [
+get_err_string = ctypes.CFUNCTYPE(
+    c_char_p,
     c_uint8  # errcode
-]
+)(('get_err_string', libc))
 
-write_pool = libc.write_pool
-write_pool.restype = None
-write_pool.argtypes = [
+write_pool = ctypes.CFUNCTYPE(
+    None,
     c_char_p,  # address
     pool_struct_p,  # pool
     genome_struct_p_p
-]
+)(('write_pool', libc))
 
-point_gene_by_index = libc.point_gene_by_index
-point_gene_by_index.restype = c_uint8_p
-point_gene_by_index.argtypes = [
+point_gene_by_index = ctypes.CFUNCTYPE(
+    c_uint8_p,
     genome_struct_p,
     pool_struct_p
-]
+)(('point_gene_by_index', libc))
 
-get_gene_by_index = libc.get_gene_by_index
-get_gene_by_index.restype = gene_struct_p
-get_gene_by_index.argtypes = [
+get_gene_by_index = ctypes.CFUNCTYPE(
+    gene_struct_p,
     genome_struct_p,
     pool_struct_p
-]
+)(('get_gene_by_index', libc))
 
-get_gene_by_pointer = libc.get_gene_by_pointer
-get_gene_by_pointer.restype = gene_struct_p
-get_gene_by_pointer.argtypes = [
+get_gene_by_pointer = ctypes.CFUNCTYPE(
+    gene_struct_p,
     gene_p,  # pointer
     pool_struct_p
-]
+)(('get_gene_by_pointer', libc))
 
-read_pool = libc.read_pool
-read_pool.restype = pool_struct_p
-read_pool.argtypes = [
+read_pool = ctypes.CFUNCTYPE(
+    pool_struct_p,
     c_char_p  # address
-]
+)(('read_pool', libc))
 
-# close_pool = ctypes.CFUNCTYPE(None, pool_struct_p)
-
-read_next_genome = libc.read_next_genome
-read_next_genome.restype = genome_struct_p
-read_next_genome.argtypes = [
+read_next_genome = ctypes.CFUNCTYPE(
+    genome_struct_p,
     pool_struct_p
-]
+)(('read_next_genome', libc))
 
-read_genomes = libc.read_genomes
-read_genomes.restype = genome_struct_p_p
-read_genomes.argtypes = [
+read_genomes = ctypes.CFUNCTYPE(
+    genome_struct_p_p,
     pool_struct_p
-]
+)(('read_genomes', libc))
 
-reset_genome_cursor = libc.reset_genome_cursor
-reset_genome_cursor.restype = None
-reset_genome_cursor.argtypes = [pool_struct_p]
+reset_genome_cursor = ctypes.CFUNCTYPE(
+    None, pool_struct_p
+)(('reset_genome_cursor', libc))
 
-free_genomes_ptrs = libc.free_genomes_ptrs
-free_genomes_ptrs.restype = None
-free_genomes_ptrs.argtypes = [
+free_genomes_ptrs = ctypes.CFUNCTYPE(
+    None,
     genome_struct_p_p
-]
+)(('free_genomes_ptrs', libc))

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -18,6 +18,9 @@ class gene_struct_t(ctypes.Structure):
     ]
 
 
+gene_struct_p = ctypes.POINTER(gene_struct_t)
+
+
 class genome_struct_t(ctypes.Structure):
     _fields_ = [
         ("length", c_uint32),
@@ -29,12 +32,18 @@ class genome_struct_t(ctypes.Structure):
     ]
 
 
+genome_struct_p = ctypes.POINTER(genome_struct_t)
+
+
 class file_mapping_struct_t(ctypes.Structure):
     _fields_ = [
         ("descriptor", ctypes.c_int),
         ("size", ctypes.c_size_t),
         ("data", c_void_p)
     ]
+
+
+file_mapping_struct_p = ctypes.POINTER(file_mapping_struct_t)
 
 
 class pool_struct_t(ctypes.Structure):
@@ -51,6 +60,9 @@ class pool_struct_t(ctypes.Structure):
         ("first_genome_start_position", c_void_p),
         ("cursor", c_void_p)
     ]
+
+
+pool_struct_p = ctypes.POINTER(pool_struct_t)
 
 
 get_err_string = libc.get_err_string

--- a/genevo/c_definitions.py
+++ b/genevo/c_definitions.py
@@ -100,7 +100,9 @@ get_gene_by_pointer = ctypes.CFUNCTYPE(
 
 generate_genes_byte_array = ctypes.CFUNCTYPE(
     gene_p,
-    gene_struct_p_p
+    gene_struct_p_p,
+    pool_struct_p,
+    c_uint64  # number of genes
 )(('generate_genes_byte_array', libc))
 
 read_pool = ctypes.CFUNCTYPE(

--- a/genevo/lazy.py
+++ b/genevo/lazy.py
@@ -2,7 +2,7 @@
 """
 
 
-class LazyStub:
+class _LazyStub:
     """Creates stub for some value which has not been initialized yet.
     """
 

--- a/genevo/lazy.py
+++ b/genevo/lazy.py
@@ -1,0 +1,26 @@
+"""This module contains class for creating lazy stubs.
+"""
+
+
+class LazyStub:
+    """Creates stub for some value which has not been initialized yet.
+    """
+
+    def __init__(self, initfunc, *args, **kwargs):
+        """Creates a stub which can be initialized with the `initfunc`. All the
+        *args and **kwargs will be passed into initfunc.
+        """
+        self._func = initfunc
+        self._args = args
+        self._kwargs = kwargs
+        self._result = None
+        self._initialized = False
+
+    def init(self, *args, **kwargs):
+        """Initialize the stub. You can freely replace it by the result of this
+        function. Anyway, function won't be executed twice.
+        You can add additional *args and **kwargs here.
+        """
+        self._result = self._func(*args, *self._args, **kwargs, **self._kwargs)
+        self._initialized = True
+        return self._result

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -40,7 +40,7 @@ class Gene:
 
         if weight_unnormalized is None and weight is None:
             raise ValueError(
-                "bot `weight_unnormalized` and `weight` cannot be None")
+                "both `weight_unnormalized` and `weight` cannot be None")
 
         self._pool = pool
         self._outcome_node_id = outcome_node_id

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -233,6 +233,11 @@ class Gene(_HasStructBackend):
 
     @property
     def gene_bytes(self) -> c_definitions.gene_p:
+
+        if self._gene_bytes is None:
+            self._gene_bytes = c_definitions.generate_genes_byte_array(
+                self.struct_ref, self._pool.struct_ref, 1)
+
         return self._gene_bytes
 
 

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -1,0 +1,151 @@
+import typing
+import enum
+
+from . import c_definitions
+
+
+def max_for_bit(size: int) -> int:
+    """Returns a number which has all `size` bits set to 1.
+
+    Examples:
+        >>> bin(max_for_bit(3))
+        <<< 0b111
+        >>> bin(max_for_bit(0))
+        <<< 0b0
+    """
+    if size >= 0:
+        return (1 << size) - 1
+    else:
+        raise ValueError("`size` should be non negative number")
+
+
+class NodeConnectionType(enum.Enum):
+    is_input = 0b10000000
+    is_intermediate = 0b01000000
+    is_output = 0b00100000
+
+
+class Gene:
+    def __init__(
+        self,
+        pool: "GenePool",
+        outcome_node_id: int,
+        outocome_node_type: NodeConnectionType,
+        income_node_id: int,
+        income_node_type: NodeConnectionType,
+        weight_unnormalized: int = None,
+        weight: int = None,
+        struct: c_definitions.gene_struct_t = None,
+        gene_bytes: c_definitions.gene_p = None
+    ):
+
+        if weight_unnormalized is None and weight is None:
+            raise ValueError(
+                "bot `weight_unnormalized` and `weight` cannot be None")
+
+        self._pool = pool
+        self._outcome_node_id = outcome_node_id
+        self._outocome_node_type = outocome_node_type
+        self._income_node_id = income_node_id
+        self._income_node_type = income_node_type
+        self._weight_unnormalized = weight_unnormalized
+        self._weight = weight
+        self._struct = struct
+        self._gene_bytes = gene_bytes
+
+    @property
+    def weight(self) -> float:
+        if self._weight is None:
+            self._weight = (
+                self._weight_unnormalized /
+                self._pool._weight_normalization_coeff
+            )
+        return self._weight
+
+    @property
+    def weight_unnormalized(self) -> int:
+        if self._weight_unnormalized is None:
+            self._weight_unnormalized = int(
+                self._weight * self._pool._weight_normalization_coeff
+            )
+        return self._weight_unnormalized
+
+    @property
+    def outcome_node(self) -> typing.Tuple[NodeConnectionType, int]:
+        return (self._outcome_node_id, self._outocome_node_type)
+
+    @property
+    def income_node(self) -> typing.Tuple[NodeConnectionType, int]:
+        return (self._income_node_id, self._income_node_type)
+
+    @property
+    def struct(self) -> c_definitions.gene_struct_t:
+        return self._struct
+
+    @property
+    def gene_bytes(self) -> c_definitions.gene_p:
+        return self._gene_bytes
+
+    @classmethod
+    def from_bytes(
+        pool: "GenePool", gene_bytes: c_definitions.gene_p
+    ):
+        raise NotImplementedError
+
+    @classmethod
+    def from_struct(
+        pool: "GenePool", self, struct: c_definitions.gene_struct_t
+    ):
+        raise NotImplementedError
+
+
+class Genome:
+    def __init__(
+        self,
+        metadata: str,
+        genes: typing.Union[typing.List[Gene], typing.List[int]],
+        residue: typing.List[int]
+    ):
+        self.metadata = metadata
+        self.genes = genes
+        self.residue = residue
+
+    @classmethod
+    def from_struct(self, string: c_definitions.genome_t):
+        pass
+
+
+class GenePool:
+
+    def __init__(
+        self,
+        input_neurons_number: int,
+        output_neurons_number: int,
+        metadata: str,
+        node_id_part_bit_size: int,
+        weight_part_bit_size: int,
+        genomes: typing.List[Genome] = None,
+        file_address: str = None
+    ):
+        self.input_neurons_number = input_neurons_number
+        self.output_neurons_number = output_neurons_number
+        self.metadata = metadata
+        self.node_id_part_bit_size = node_id_part_bit_size
+        self.weight_part_bit_size = weight_part_bit_size
+        self.genomes = genomes or []
+        self.file_address = file_address
+
+    @property
+    def gene_bits_size(self):
+        raise NotImplementedError
+
+    @property
+    def gene_bytes_size(self):
+        raise NotImplementedError
+
+    @property
+    def _weight_normalization_coeff(self):
+        """A coefficient, which satisfies the following condition:
+        > weight_unnormalized / COEFF = weight.
+        """
+        return max_for_bit(self.gene_bits_size)

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -242,14 +242,21 @@ class _BitField(_IterableContainer):
             *args, **kwargs
         )
 
-    def to_dynamic_array(self) -> c_definitions.c_uint8_p:
+    def to_dynamic_array(self) -> tuple[int, c_definitions.c_uint8_p]:
+        """Allocates dynamic array (if wasn't allocated yet) for the bytes
+        inside this bit field.
+
+        Returns:
+            tuple[0], int; Size of the array.
+            tuple[1], c_uint8_p; The array itself.
+
+        """
 
         if isinstance(self._bytes, c_definitions.c_uint8_p):
-            return self._bytes
+            return self._bytes_len, self._bytes
 
-        return (c_definitions.c_uint8_p * self._bytes_len)(*map(
-            c_definitions.c_uint8, self._bytes
-        ))
+        return self._bytes_len, (c_definitions.c_uint8_p * self._bytes_len)(
+            *map(c_definitions.c_uint8, self._bytes))
 
     @property
     def number(self) -> int:

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -132,6 +132,12 @@ class Gene(_HasStructBackend):
         self._struct_ref = struct_ref
         self._gene_bytes = gene_bytes
 
+    def __repr__(self):
+        return (
+            f"<Gene "
+            f"{self._outcome_node_id} -> {self._income_node_id}, "
+            f"weight={self._weight}>")
+
     def _generate_struct_ref(self) -> c_definitions.gene_struct_p:
         return c_definitions.ctypes.pointer(c_definitions.gene_struct_t(
             # outcome_node_id
@@ -451,6 +457,9 @@ class Genome(_IterableContainer, _HasStructBackend):
         else:
             self._genes = genes
 
+    def __repr__(self):
+        return f"<Genome with {len(self)} genes>"
+
     def _generate_struct_ref(self) -> c_definitions.genome_struct_p:
         super()._generate_struct_ref()
         metadata = self._metadata.encode("utf-8")
@@ -577,6 +586,9 @@ class GenePool(_IterableContainer, _HasStructBackend):
         self._struct_ref = struct_ref
 
         self._range_starts = None
+
+    def __repr__(self):
+        return f"<GenePool with {len(self)} genomes>"
 
     @classmethod
     def from_struct(cls, struct_ref: c_definitions.pool_struct_t):

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -378,6 +378,14 @@ class GenePool(_IterableContainer):
             struct=pool_struct_p
         )
 
+    def dump_to_file(self, address: str):
+        """Dump the pool into the file with given address.
+        """
+        c_definitions.write_pool(
+            address.encode("utf-8"),
+            self.struct, self.genome_structs_vector)
+        errors.check_errors()
+
     def _generate_struct(self) -> c_definitions.pool_struct_p:
         """Generate C struct pool_struct_p for this gene pool.
         """

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -186,15 +186,9 @@ class Gene(_HasStructBackend):
 
         return cls(
             pool=pool,
-            outcome_node_id=(
-                struct.outcome_node_id -
-                pool.range_starts[outcome_node_type]
-            ),
+            outcome_node_id=struct.outcome_node_id,
             outcome_node_type=outcome_node_type,
-            income_node_id=(
-                struct.income_node_id -
-                pool.range_starts[income_node_type]
-            ),
+            income_node_id=struct.income_node_id,
             income_node_type=income_node_type,
             weight_unnormalized=struct.weight_unnormalized,
             weight=struct.weight,

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -702,7 +702,7 @@ class GenePool(_IterableContainer, _HasStructBackend):
     def genomes(self):
         return self._genomes
 
-    def eliminate(self, eliminator: typing.Callable[Genome, bool]):
+    def eliminate(self, eliminator: typing.Callable[[Genome], bool]):
         pass
 
     def reproduce(self, kill_parents: float = 0) -> "GenePool":

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -177,11 +177,15 @@ class Gene(_HasStructBackend):
         return self._weight_unnormalized
 
     @property
-    def outcome_node(self) -> tuple[NodeConnectionType, int]:
+    # For Python3.10
+    # def outcome_node(self) -> tuple[NodeConnectionType, int]:
+    def outcome_node(self) -> typing.Tuple[NodeConnectionType, int]:
         return (self._outcome_node_id, self._outcome_node_type)
 
     @property
-    def income_node(self) -> tuple[NodeConnectionType, int]:
+    # For Python3.10
+    # def income_node(self) -> tuple[NodeConnectionType, int]:
+    def income_node(self) -> typing.Tuple[NodeConnectionType, int]:
         return (self._income_node_id, self._income_node_type)
 
     @property
@@ -198,10 +202,14 @@ class _BitField(_IterableContainer):
 
     def __init__(
         self,
-        byte_array: iter[int],
+        # byte_array: iter[int],  # For Python3.10
+        byte_array: typing.Iterable[int],
         bytes_size: int = None,
         skip_last_bits: int = 0,
-        grouping: _GroupingType | int = _GroupingType.group_by_byte,
+        # For Python3.10
+        # grouping: _GroupingType | int = _GroupingType.group_by_byte,
+        grouping: typing.Union[_GroupingType, int] =
+            _GroupingType.group_by_byte,
         skip_byte_size_checking: bool = False
     ):
         """Creates BitField.
@@ -265,7 +273,8 @@ class _BitField(_IterableContainer):
     @staticmethod
     def _copy_bytes(
         byte_array: c_definitions.c_uint8_p, bytes_size: int
-    ) -> list[int]:
+    # ) -> list[int]:  # For Python3.10
+    ) -> typing.List[int]:
         return [
             byte.value
             for _, byte
@@ -300,7 +309,8 @@ class _BitField(_IterableContainer):
     def to_dynamic_array(
         self,
         realloc: bool = False
-    ) -> tuple[int, c_definitions.c_uint8_p]:
+    # ) -> tuple[int, c_definitions.c_uint8_p]:  # For Python3.10
+    ) -> typing.Tuple[int, c_definitions.c_uint8_p]:
         """Allocates dynamic array (if wasn't allocated yet) for the bytes
         inside this bit field.
 
@@ -384,7 +394,8 @@ class Genome(_IterableContainer, _HasStructBackend):
         self,
         pool: "GenePool",
         metadata: str,
-        genes: list[Gene],
+        # genes: list[Gene],  # For Python3.10
+        genes: typing.Union[lazy.LazyStub, typing.List[Gene]],
         genes_residue: GenomeResidue = None,
         genome_struct_ref: c_definitions.genome_struct_p = None,
     ):
@@ -407,7 +418,9 @@ class Genome(_IterableContainer, _HasStructBackend):
         ))
 
     @property
-    def _gene_bytes(self) -> tuple[int, c_definitions.gene_p]:
+    # For Python3.10
+    # def _gene_bytes(self) -> tuple[int, c_definitions.gene_p]:
+    def _gene_bytes(self) -> typing.Tuple[int, c_definitions.gene_p]:
         """Returns array if bytes for genes. If the genome has no its struct
         yet, then new array will be allocated.
         """
@@ -463,7 +476,8 @@ class Genome(_IterableContainer, _HasStructBackend):
         return self.genes[index]
 
     @property
-    def genes(self) -> list[Gene]:
+    # def genes(self) -> list[Gene]:  # For Python3.10
+    def genes(self) -> typing.List[Gene]:
         return self._genes
 
     @property
@@ -493,7 +507,8 @@ class GenePool(_IterableContainer, _HasStructBackend):
         metadata: str,
         node_id_part_bit_size: int,
         weight_part_bit_size: int,
-        genomes: list[Genome] = None,
+        # genomes: list[Genome] = None,  # For Python3.10
+        genomes: typing.List[Genome] = None,
         struct: c_definitions.pool_struct_p = None
     ):
         self._input_neurons_number = input_neurons_number

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -383,15 +383,17 @@ class GenomeResidue(_BitField):
 class Genome(_IterableContainer, _HasStructBackend):
     def __init__(
         self,
+        pool: "GenePool",
         metadata: str,
         genes: list[Gene],
         genes_residue: GenomeResidue = None,
-        struct: c_definitions.genome_struct_p = None
+        genome_struct_ref: c_definitions.genome_struct_p = None,
     ):
         self._metadata = metadata
         self._genes = genes
         self._residue = genes_residue
-        self._struct = struct
+        self._struct = genome_struct_ref
+        self._pool = pool
 
     def _generate_struct(self) -> c_definitions.genome_struct_p:
         super()._generate_struct()
@@ -416,7 +418,9 @@ class Genome(_IterableContainer, _HasStructBackend):
         else:
             return c_definitions.generate_genes_byte_array(
                 (c_definitions.gene_struct_p * len(self))(
-                    *[gene.struct for gene in self.genes]
+                    *[gene.struct for gene in self.genes],
+                    self._pool._struct,
+                    len(self.genes)
                 )
             )
 

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -405,11 +405,12 @@ class GenePool(_IterableContainer):
         ))
 
     @property
-    def genome_structs_vector(self) -> c_definitions.genome_struct_p:
-        return (c_definitions.genome_struct_p * len(self))(*[
-            genome.struct
-            for genome in self.genomes
-        ])
+    def genome_structs_vector(self) -> c_definitions.genome_struct_p_p:
+        return c_definitions.ctypes.pointer(
+            (c_definitions.genome_struct_p * len(self))(*[
+                genome.struct for genome in self.genomes
+            ])
+        )
 
     @property
     def gene_bits_size(self) -> int:

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -1,6 +1,6 @@
 import enum
-import itertools
 import typing
+import itertools
 
 from . import c_definitions
 
@@ -109,13 +109,115 @@ class _BitField:
 
     def __init__(
         self,
+        bytes: iter[int],
+        skip_last_bits: int = 0,
         grouping: _GroupingType | int = _GroupingType.group_by_byte,
-        skip_last_bits: int = 0
+        skip_byte_size_checking: bool = False
     ):
-        raise NotImplementedError
+        """Creates BitField.
 
-    def __getitem__(self, key: int | slice) -> Gene:
-        raise NotImplementedError
+        Arguments:
+            skip_last_bits: int, default = 0; Last given number of bits of the
+                last byte wont be considered as the part of the current bit
+                field.
+                Suppose you have defined bit field with bytes [0xff, 0xff].
+                With `skip_last_bits`=0 size of the bit field will be 16 bits,
+                but with `skip_last_bits`=3 the size is equal to 13.
+                This argument should be no bigger than 7.
+            skip_byte_size_checking: bool, default = False; If set to False
+                than each given int will be checked to have no more than 8
+                significant bits.
+                In case this check is disabled and one of the given numbers
+                is bigger than 8 bits, any higher bits will be omited.
+            grouping: int, default = _GroupingType.group_by_byte (==8); Defines
+                the size of the items in the bit field. For example, if
+                grouping is set to 10, than indexing inside this container will
+                give 10-bit numbers.
+
+        """
+        if not (skip_last_bits < 8):
+            raise ValueError(
+                "you can't skip more than 7 bits of the last byte, just pass "
+                "the one byte less")
+
+        self._grouping_size = (
+            grouping.value if isinstance(grouping, _GroupingType)
+            else grouping
+        )
+
+        if not (self._grouping_size >= 1):
+            raise ValueError("grouping size cannot be less than 1")
+
+        self._bit_size = len(bytes) * 8 - skip_last_bits
+
+        if self._bit_size % self._grouping_size:  # != 0
+            raise ValueError(
+                "invalid combination of `skil_last_bits` and `grouping`; some "
+                "of the last bits won't be ever indexed")
+
+        if not skip_byte_size_checking:
+            for index, byte in enumerate(self._bytes):
+                if byte.bit_count() > 8:
+                    raise ValueError(
+                        f"number at position {index} is equal to {byte} has "
+                        "more than 8 significant bits")
+
+        # Converts array
+        # [n_0, ..., n_l] to number
+        # (n_0 << (l * 8)) + ... + (n_l << 0). That means
+        # [0xab, 0xcd, 0xef, 0x01] will become 0xabcdef01
+        self._number = sum(
+            byte << (shift * 8)
+            for byte, shift
+            in zip(
+                bytes,
+                reversed(range(len(bytes)))
+            )
+        )
+
+        # Right shift unsignificant bits to the right, so cutting it off
+        self._number >>= skip_last_bits
+
+    @property
+    def bit_length(self):
+        return self._bit_size
+
+    @property
+    def groups_length(self):
+        """Return number of groups inside the bit field.
+        """
+        return self._bit_size // self._grouping_size
+
+    def __len__(self) -> int:
+        """Returns number of groups.
+        """
+        return self.groups_length
+
+    def _get_by_index(self, index: int) -> int:
+        """Get a single number from bit field by its index.
+        """
+        bit_start = \
+            self._bit_size - index * self._grouping_size - self._grouping_size
+
+        if bit_start < 0:
+            raise IndexError
+
+        return self._number & (max_for_bit(self._grouping_size) << bit_start)
+
+    def __getitem__(self, key: int | slice) -> Gene | list[Gene]:
+
+        if isinstance(key, slice):
+            # map list of indices with a such function which extracts an item
+            # by its index
+            return list(map(
+                self._get_by_index,
+                itertools.islice(  # produce indices for extraction
+                    range(self.groups_length),
+                    key.start, key.stop, key.step)
+            ))
+
+        else:
+            return self._get_by_index(key)
 
 
 class GenomeResidue(_BitField):
@@ -124,25 +226,30 @@ class GenomeResidue(_BitField):
         bytes: list[int] | c_definitions.gene_p,
         bit_size: int
     ):
-        super().__init__()
-        raise NotImplementedError
+        full_bytes_size = (bit_size // 8) + 1
 
+        if isinstance(bytes, c_definitions.gene_p):
+            bytes_list = [
+                bytes[index].value
+                for index in range(full_bytes_size)
+            ]
 
-class GeneSequence(_BitField):
-    def __init__(
-        self,
-        bytes: list[Gene] | c_definitions.gene_p,
-        gene_byte_size: int
-    ):
-        super().__init__()
-        raise NotImplementedError
+        else:
+            bytes_list = bytes
+
+        super().__init__(
+            bytes=bytes_list,
+            skip_last_bits=(full_bytes_size * 8 - bit_size),
+            grouping=_GroupingType.group_by_bit,
+            skip_byte_size_checking=True
+        )
 
 
 class Genome:
     def __init__(
         self,
         metadata: str,
-        genes: GeneSequence,
+        genes: list[Gene],
         genes_residue: GenomeResidue = None,
         struct: c_definitions.genome_struct_p = None
     ):
@@ -153,24 +260,26 @@ class Genome:
 
     @property
     def struct(self) -> c_definitions.gene_struct_p:
+        if not self._struct:
+            raise NotImplementedError(
+                "struct generation is not implemented yet")
         return self._struct
+
+    @property
+    def residue_bit_size(self):
+        return self._residue.bit_length
 
     @classmethod
     def from_struct(self, string: c_definitions.genome_t):
         pass
 
     @property
-    def genes(self) -> GeneSequence:
+    def genes(self) -> list[Gene]:
         return self._genes
 
     @property
     def genes_residue(self) -> GenomeResidue:
         return self._residue
-
-    @property
-    def bit_iter(self) -> typing.Generator[int]:
-        yield from self._genes.bit_iter
-        yield from self._residue.bit_iter
 
     def mutate(self):
         pass
@@ -207,6 +316,10 @@ class GenePool:
         self._genomes = genomes or []
         self._file_address = file_address
         self._struct = struct
+
+    @classmethod
+    def from_file_dump(cls, address: str) -> "GenePool":
+        pass
 
     @property
     def struct(self) -> c_definitions.gene_struct_p:

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -63,6 +63,12 @@ class _HasStructBackend:
     def _generate_struct(self) -> c_definitions.ctypes.Structure:
         pass
 
+    def refresh_struct(self):
+        """Deletes the struct, so new one will be generated next time you
+        access `struct` property.
+        """
+        self._struct = None
+
     @property
     def struct(self) -> c_definitions.ctypes.Structure:
         if not self._struct:

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -198,7 +198,7 @@ class Gene(_HasStructBackend):
             income_node_type=income_node_type,
             weight_unnormalized=struct.weight_unnormalized,
             weight=struct.weight,
-            struct=struct_ref,
+            struct_ref=struct_ref,
             gene_bytes=None
         )
 
@@ -499,6 +499,7 @@ class Genome(_IterableContainer, _HasStructBackend):
         ]
 
         return cls(
+            pool=pool,
             metadata=bytes(
                 genome_struct.metadata[:genome_struct.metadata_byte_size]
             ).decode("utf-8"),
@@ -678,7 +679,7 @@ class GenePool(_IterableContainer, _HasStructBackend):
             dict[key]: NodeConnectionType
             dict[value]: Start range
         """
-        if self._range_starts is not None:
+        if self._range_starts is None:
 
             self._range_starts = dict(zip(
                 [

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -197,6 +197,10 @@ class Gene(_HasStructBackend):
         )
 
     @property
+    def pool(self):
+        return self._pool
+
+    @property
     def weight(self) -> float:
         if self._weight is None:
             self._weight = (
@@ -458,6 +462,10 @@ class Genome(_IterableContainer, _HasStructBackend):
             self._residue.bit_length,
             self._residue.to_dynamic_array()
         ))
+
+    @property
+    def pool(self):
+        return self._pool
 
     @property
     # For Python3.10

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -1,4 +1,3 @@
-import typing
 import enum
 
 from . import c_definitions
@@ -35,7 +34,7 @@ class Gene:
         income_node_type: NodeConnectionType,
         weight_unnormalized: int = None,
         weight: int = None,
-        struct: c_definitions.gene_struct_t = None,
+        struct: c_definitions.gene_struct_p = None,
         gene_bytes: c_definitions.gene_p = None
     ):
 
@@ -71,15 +70,15 @@ class Gene:
         return self._weight_unnormalized
 
     @property
-    def outcome_node(self) -> typing.Tuple[NodeConnectionType, int]:
+    def outcome_node(self) -> tuple[NodeConnectionType, int]:
         return (self._outcome_node_id, self._outocome_node_type)
 
     @property
-    def income_node(self) -> typing.Tuple[NodeConnectionType, int]:
+    def income_node(self) -> tuple[NodeConnectionType, int]:
         return (self._income_node_id, self._income_node_type)
 
     @property
-    def struct(self) -> c_definitions.gene_struct_t:
+    def struct(self) -> c_definitions.gene_struct_p:
         return self._struct
 
     @property
@@ -94,7 +93,7 @@ class Gene:
 
     @classmethod
     def from_struct(
-        pool: "GenePool", self, struct: c_definitions.gene_struct_t
+        pool: "GenePool", self, struct: c_definitions.gene_struct_p
     ):
         raise NotImplementedError
 
@@ -124,7 +123,7 @@ class GenePool:
         metadata: str,
         node_id_part_bit_size: int,
         weight_part_bit_size: int,
-        genomes: typing.List[Genome] = None,
+        genomes: list[Genome] = None,
         file_address: str = None
     ):
         self.input_neurons_number = input_neurons_number

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -443,7 +443,7 @@ class Genome(_IterableContainer, _HasStructBackend):
         pool: "GenePool",
         metadata: str,
         # genes: list[Gene],  # For Python3.10
-        genes: typing.Union[lazy.LazyStub, typing.List[Gene]],
+        genes: typing.Union[lazy._LazyStub, typing.List[Gene]],
         genes_residue: GenomeResidue = None,
         genome_struct_ref: c_definitions.genome_struct_p = None,
     ):
@@ -452,7 +452,7 @@ class Genome(_IterableContainer, _HasStructBackend):
         self._struct_ref = genome_struct_ref
         self._pool = pool
 
-        if isinstance(genes, lazy.LazyStub):
+        if isinstance(genes, lazy._LazyStub):
             self._genes = genes.initialize(pool=self)
         else:
             self._genes = genes

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -117,7 +117,6 @@ class Gene(_HasStructBackend):
             self.weight_unnormalized,
             self.weight
         ))
-        raise NotImplementedError
 
     @classmethod
     def from_bytes(
@@ -454,7 +453,7 @@ class Genome(_IterableContainer, _HasStructBackend):
                 copy_bytes=False
 
             ),
-            struct=genome_struct_ref
+            genome_struct_ref=genome_struct_ref
         )
 
     def __len__(self) -> int:
@@ -518,9 +517,9 @@ class GenePool(_IterableContainer, _HasStructBackend):
         genomes = []
 
         try:
-            genome_struct = c_definitions.read_next_genome(pool_struct_p)
+            genome_struct_p = c_definitions.read_next_genome(pool_struct_p)
             errors.check_errors()
-            genomes.append(Genome.from_struct(genome_struct))
+            genomes.append(Genome.from_struct(genome_struct_p, pool_struct_p))
 
         except StopIteration:
             pass

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -243,17 +243,26 @@ class _BitField(_IterableContainer):
             *args, **kwargs
         )
 
-    def to_dynamic_array(self) -> tuple[int, c_definitions.c_uint8_p]:
+    def to_dynamic_array(
+        self,
+        realloc: bool = False
+    ) -> tuple[int, c_definitions.c_uint8_p]:
         """Allocates dynamic array (if wasn't allocated yet) for the bytes
         inside this bit field.
+
+        Arguments:
+            realloc: bool, default = False; If True then new array will be
+                allocated.
 
         Returns:
             tuple[0], int; Size of the array.
             tuple[1], c_uint8_p; The array itself.
-
         """
 
-        if isinstance(self._byte_array, c_definitions.c_uint8_p):
+        if (
+            isinstance(self._byte_array, c_definitions.c_uint8_p) and
+            not realloc
+        ):
             return self._bytes_len, self._byte_array
 
         return self._bytes_len, (c_definitions.c_uint8_p * self._bytes_len)(

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -29,8 +29,8 @@ class NodeConnectionType(enum.Enum):
     is_output = 0b00100000
 
 
-_INCOME_CONNECTION_TYPE_BITMASK = 0b11100000
-_OUTCOME_CONNECTION_TYPE_BITMASK = 0b00011100
+_OUTCOME_CONNECTION_TYPE_BITMASK = 0b11100000
+_INCOME_CONNECTION_TYPE_BITMASK = 0b00011100
 
 
 class _IterableContainer(metaclass=abc.ABCMeta):
@@ -141,7 +141,7 @@ class Gene(_HasStructBackend):
             (self._income_node_id +
              self.pool.range_starts[self._income_node_type]),
             # connection_type
-            self.outcome_node_type.value + self.income_node_type.value >> 3,
+            self.outcome_node_type + self.income_node_type >> 3,
             self.weight_unnormalized,
             self.weight
         ))

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -178,26 +178,26 @@ class Gene(_HasStructBackend):
     ):
         struct = struct_ref.contents
 
-        connection_type = struct.connection_type.value
+        connection_type = struct.connection_type
         outcome_node_type = NodeConnectionType(
             connection_type & _OUTCOME_CONNECTION_TYPE_BITMASK)
         income_node_type = NodeConnectionType(
-            connection_type & _INCOME_CONNECTION_TYPE_BITMASK)
+            (connection_type & _INCOME_CONNECTION_TYPE_BITMASK) << 3)
 
         return cls(
             pool=pool,
             outcome_node_id=(
-                struct.outcome_node_id.value -
+                struct.outcome_node_id -
                 pool.range_starts[outcome_node_type]
             ),
             outcome_node_type=outcome_node_type,
             income_node_id=(
-                struct.income_node_id.value -
+                struct.income_node_id -
                 pool.range_starts[income_node_type]
             ),
             income_node_type=income_node_type,
-            weight_unnormalized=struct.weight_unnormalized.value,
-            weight=struct.weight.value,
+            weight_unnormalized=struct.weight_unnormalized,
+            weight=struct.weight,
             struct=struct_ref,
             gene_bytes=None
         )
@@ -318,11 +318,7 @@ class _BitField(_IterableContainer):
         byte_array: c_definitions.c_uint8_p, bytes_size: int
     # ) -> list[int]:  # For Python3.10
     ) -> typing.List[int]:
-        return [
-            byte.value
-            for _, byte
-            in zip(range(bytes_size), byte_array)
-        ]
+        return byte_array[:bytes_size]
 
     @classmethod
     def from_dynamic_array(

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -113,7 +113,7 @@ class Gene(_HasStructBackend):
             (self._income_node_id +
              self.pool.range_starts[self._income_node_type]),
             # connection_type
-            self.outcome_node_type + self.income_node_type >> 3,
+            self.outcome_node_type.value + self.income_node_type.value >> 3,
             self.weight_unnormalized,
             self.weight
         ))

--- a/genevo/pool.py
+++ b/genevo/pool.py
@@ -641,8 +641,24 @@ class GenePool(_IterableContainer, _HasStructBackend):
         ))
 
     @property
+    def input_neurons_number(self):
+        return self._input_neurons_number
+
+    @property
+    def output_neurons_number(self):
+        return self._output_neurons_number
+
+    @property
     def nodes_capacity(self) -> int:
         return _max_for_bit(self._node_id_part_bit_size)
+
+    @property
+    def node_id_part_bit_size(self) -> int:
+        return self._node_id_part_bit_size
+
+    @property
+    def weight_part_bit_size(self) -> int:
+        return self._weight_part_bit_size
 
     @property
     def range_starts(self) -> dict:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+
+with open("README.md", mode="r", encoding="utf-8") as file:
+    long_description = file.read()
+
+setuptools.setup(
+    name="genevo",
+    version="0.0.1",
+    author="Pavlo Tymoshenko",
+    author_email="p.tymoshen@gmail.com",
+    description="Framework for evolutional neural networks",
+    long_description=long_description,
+    python_requires=">=3.5",
+    long_description_content_type="text/markdown",
+    url="https://github.com/lynnporu/genevo",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Development Status :: 1 - Planning",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: POSIX :: Linux",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence"
+    ],
+    package_dir={"": "genevo"},
+    packages=setuptools.find_packages(where="genevo")
+)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     author_email="p.tymoshen@gmail.com",
     description="Framework for evolutional neural networks",
     long_description=long_description,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     long_description_content_type="text/markdown",
     url="https://github.com/lynnporu/genevo",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setuptools.setup(
     author_email="p.tymoshen@gmail.com",
     description="Framework for evolutional neural networks",
     long_description=long_description,
-    python_requires=">=3.5",
+    python_requires=">=3.9",
     long_description_content_type="text/markdown",
     url="https://github.com/lynnporu/genevo",
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 1 - Planning",
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
This PR implements Python wrapper for underlying C functions related to file dumping and reading. It also provide fixes for C machinery, so now it works properly.

List of changes included in this PR:
* Implemented `Gene`, `Genome` (aka `Organism`) and `GenePool` (aka `Population`) classes
* Created ctypes declarations for used C methods and types
* Added `_LazyStub`, `_HasStructBackend` and `_IterableContainer` routine classes
* Fixes for C functions related to file dumping and reading
* Manifest for setuptools